### PR TITLE
(doc) Remove leading whitespace

### DIFF
--- a/espanso/espanso.nuspec
+++ b/espanso/espanso.nuspec
@@ -9,83 +9,83 @@
     <owners>Jonas A. Wendorf</owners>
     <summary>Cross-platform Text Expander written in Rust</summary>
     <description>
-        ![espanso](https://raw.githubusercontent.com/federico-terzi/espanso/master/images/titlebar.png)
+![espanso](https://raw.githubusercontent.com/federico-terzi/espanso/master/images/titlebar.png)
 
-        &gt; A cross-platform Text Expander written in Rust
+&gt; A cross-platform Text Expander written in Rust
 
-        ![GitHub release (latest by date)](https://img.shields.io/github/v/release/federico-terzi/espanso)
-        ![Language](https://img.shields.io/badge/language-rust-orange)
-        ![Platforms](https://img.shields.io/badge/platforms-Windows%2C%20macOS%20and%20Linux-blue)
-        ![License](https://img.shields.io/github/license/federico-terzi/espanso)
-        [![Build Status](https://dev.azure.com/freddy6896/espanso/_apis/build/status/federico-terzi.espanso?branchName=master)](https://dev.azure.com/freddy6896/espanso/_build/latest?definitionId=1&amp;branchName=master)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/federico-terzi/espanso)
+![Language](https://img.shields.io/badge/language-rust-orange)
+![Platforms](https://img.shields.io/badge/platforms-Windows%2C%20macOS%20and%20Linux-blue)
+![License](https://img.shields.io/github/license/federico-terzi/espanso)
+[![Build Status](https://dev.azure.com/freddy6896/espanso/_apis/build/status/federico-terzi.espanso?branchName=master)](https://dev.azure.com/freddy6896/espanso/_build/latest?definitionId=1&amp;branchName=master)
 
-        ![example](https://raw.githubusercontent.com/federico-terzi/espanso/master/images/example.gif)
+![example](https://raw.githubusercontent.com/federico-terzi/espanso/master/images/example.gif)
 
-        Visit the [espanso website](https://espanso.org).
+Visit the [espanso website](https://espanso.org).
 
-        #### What is a Text Expander?
+#### What is a Text Expander?
 
-        A *text expander* is a program that detects when you type
-        a specific **keyword** and replaces it with **something else**. 
-        This is useful in many ways:
-        * **Save a lot of typing**, expanding common sentences.
-        * Create **system-wide** code snippets.
-        * Execute **custom scripts**
-        * Use **emojis** like a pro.
+A *text expander* is a program that detects when you type
+a specific **keyword** and replaces it with **something else**.
+This is useful in many ways:
+* **Save a lot of typing**, expanding common sentences.
+* Create **system-wide** code snippets.
+* Execute **custom scripts**
+* Use **emojis** like a pro.
 
-        ___
+___
 
-        ## Key Features
+## Key Features
 
-        * Works on **Windows**, **macOS** and **Linux**
-        * Works with almost **any program**
-        * Works with **Emojis** 😄
-        * **Date** expansion support
-        * **Custom scripts** support
-        * **Shell commands** support
-        * **App-specific** configurations
-        * Expandable with **packages**
-        * Built-in **package manager** for [espanso hub](https://hub.espanso.org/)
-        * File based configuration
+* Works on **Windows**, **macOS** and **Linux**
+* Works with almost **any program**
+* Works with **Emojis** 😄
+* **Date** expansion support
+* **Custom scripts** support
+* **Shell commands** support
+* **App-specific** configurations
+* Expandable with **packages**
+* Built-in **package manager** for [espanso hub](https://hub.espanso.org/)
+* File based configuration
 
-        ## Get Started
+## Get Started
 
-        Visit the [official documentation](https://espanso.org/docs/).
+Visit the [official documentation](https://espanso.org/docs/).
 
-        ## Support
+## Support
 
-        If you need some help to setup espanso, want to ask a question or simply get involved
-        in the community, [Join the official Subreddit](https://www.reddit.com/r/espanso/)! :)
+If you need some help to setup espanso, want to ask a question or simply get involved
+in the community, [Join the official Subreddit](https://www.reddit.com/r/espanso/)! :)
 
 
 
-        ## Donations
+## Donations
 
-        espanso is a free, open source software developed in my (little) spare time.
-        If you liked the project and would like to support further development, 
-        please consider making a small donation, it really helps :)
+espanso is a free, open source software developed in my (little) spare time.
+If you liked the project and would like to support further development,
+please consider making a small donation, it really helps :)
 
-        [![Donate with PayPal](images/donate.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=FHNLR5DRS267E&amp;source=url)
+[![Donate with PayPal](images/donate.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=FHNLR5DRS267E&amp;source=url)
 
-        ## Contributors
+## Contributors
 
-        Many people helped the project along the way, thanks to all of you. In particular, I want to thank: 
+Many people helped the project along the way, thanks to all of you. In particular, I want to thank:
 
-        * [Scrumplex](https://scrumplex.net/) - Official AUR repo mantainer and Linux Guru
-        * [Luca Antognetti](https://github.com/luca-ant) - Linux and Windows Tester
-        * [Matteo Pellegrino](https://www.matteopellegrino.me/) - MacOS Tester
-        * [Timo Runge](http://timorunge.com/) - MacOS contributor
-        * [NickSeagull](http://nickseagull.github.io/) - Contributor
+* [Scrumplex](https://scrumplex.net/) - Official AUR repo mantainer and Linux Guru
+* [Luca Antognetti](https://github.com/luca-ant) - Linux and Windows Tester
+* [Matteo Pellegrino](https://www.matteopellegrino.me/) - MacOS Tester
+* [Timo Runge](http://timorunge.com/) - MacOS contributor
+* [NickSeagull](http://nickseagull.github.io/) - Contributor
 
-        ## Remarks
+## Remarks
 
-        * Special thanks to the [ModifyPath](https://www.legroom.net/software/modpath)
-          script, used by espanso to improve the Windows installer.
+* Special thanks to the [ModifyPath](https://www.legroom.net/software/modpath)
+  script, used by espanso to improve the Windows installer.
 
-        ## License
+## License
 
-        espanso was created by [Federico Terzi](http://federicoterzi.com)
-        and is licensed under the [GPL-3.0 license](https://github.com/federico-terzi/espanso/LICENSE).
+espanso was created by [Federico Terzi](http://federicoterzi.com)
+and is licensed under the [GPL-3.0 license](https://github.com/federico-terzi/espanso/LICENSE).
     </description>
     <projectUrl>https://github.com/federico-terzi/espanso</projectUrl>
     <projectSourceUrl>https://github.com/federico-terzi/espanso</projectSourceUrl>


### PR DESCRIPTION
This should make the markdown render correctly on chocolatey.org.

Currently, the markdown heading are being rendered as follows:

![image](https://user-images.githubusercontent.com/1271146/88215717-fef45a00-cc53-11ea-9ed1-daa0a96219bb.png)

This is due to the leading whitespace as the start of each line.

By removing this whitespace, the markdown should render correctly.